### PR TITLE
Add AWS KMS key

### DIFF
--- a/tf/kms.tf
+++ b/tf/kms.tf
@@ -1,0 +1,9 @@
+resource "aws_kms_key" "isuxportal" {
+  description             = "isuxportal"
+  deletion_window_in_days = 10
+}
+
+resource "aws_kms_alias" "isuxportal" {
+  name          = "alias/isuxportal"
+  target_key_id = aws_kms_key.isuxportal.key_id
+}


### PR DESCRIPTION
hako から利用する secrets を Parameter Store に格納するために使うキーを追加します。