### PR TITLE
Fix Terraform error on EcsTaskExecution

### DIFF
--- a/tf/iam-role_ecstaskexecution.tf
+++ b/tf/iam-role_ecstaskexecution.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "EcsTaskExecution-ecs" {
     actions = [
       "ssm:GetParameters",
     ]
-    resources = ["arn:aws:ssm:*:${var.aws_account_id}:parameter/hako/*"]
+    resources = ["arn:aws:ssm:*:245943874622:parameter/hako/*"]
   }
   statement {
     effect = "Allow"


### PR DESCRIPTION
#40 で追加された EcsTaskExecution 内で #29 のレビュー中に使わなくなったはずの `var.aws_account_id` が含まれていたので修正しました。レビューで見逃していて申し訳ないです。