### PR TITLE
Fix default security group name

### DIFF
--- a/tf/security-group_default.tf
+++ b/tf/security-group_default.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "default" {
   vpc_id      = aws_vpc.main.id
-  name        = "isucnon-default"
+  name        = "default"
   description = "default VPC security group"
 }
 


### PR DESCRIPTION
`isucon` を typo していたので名前を変更しました。すでに `default` と呼ばれる Security Group があり `isucon-default` も存在すると混乱しそうだったのでもともとあった `default` を Terraform 管理下に import しました。