### PR TITLE
Remove ISUXPORTAL_DCIM_TOKEN

### DIFF
--- a/hako/isuxportal-prd-base.libsonnet
+++ b/hako/isuxportal-prd-base.libsonnet
@@ -58,7 +58,6 @@ local secret = utils.makeSecretParameterStore('isuxportal-prd');
       secret('ISUXPORTAL_BYPASS_SECRET'),
       secret('ISUXPORTAL_SSH_KEY_API_SECRET'),
       secret('ISUXPORTAL_BENCH_TOKEN'),
-      secret('ISUXPORTAL_DCIM_TOKEN'),
       secret('ISUXPORTAL_VAPID_PRIVATE_KEY'),
     ],
     mount_points: [

--- a/portal/config/environments/production.rb
+++ b/portal/config/environments/production.rb
@@ -147,7 +147,7 @@ Rails.application.configure do
   config.x.bench_auth.token = ENV.fetch('ISUXPORTAL_BENCH_TOKEN')
   config.x.bypass_token.secret = ENV.fetch('ISUXPORTAL_BYPASS_SECRET').unpack1('m0') # ruby -rsecurerandom -e 'puts SecureRandom.base64(96)'
   config.x.ssh_key_api.secret = ENV.fetch('ISUXPORTAL_SSH_KEY_API_SECRET')
-  config.x.dcim.token = ENV.fetch('ISUXPORTAL_DCIM_TOKEN')
+  #config.x.dcim.token = ENV.fetch('ISUXPORTAL_DCIM_TOKEN')
 
   config.x.terms_url = ENV.fetch('ISUXPORTAL_TERMS_URL', 'https://isucon.net/archives/54800315.html')
   config.x.rules_url = ENV.fetch('ISUXPORTAL_RULES_URL', 'https://isucon.net/archives/54753430.html')


### PR DESCRIPTION
ISUCON11 では不要そうとのことなので削除しました。 ENV.fetch なのでこの変更が無いと production ではデプロイができないはず。
トークン利用してるのは gRPC 側で、参加登録までにそのコードを変更する必要は無さそうだったので環境変数だけ先に消します。

hako 側も同時に変更したので FYI @yfujit 