### PR TITLE
temporary ignore NEW_RELIC_LICENSE_KEY

### DIFF
--- a/hako/isuxportal-prd-base.libsonnet
+++ b/hako/isuxportal-prd-base.libsonnet
@@ -48,7 +48,7 @@ local secret = utils.makeSecretParameterStore('isuxportal-prd');
     secrets: [
       secret('SECRET_KEY_BASE'),
       secret('DATABASE_PASSWORD'),
-      secret('NEW_RELIC_LICENSE_KEY'),
+//      secret('NEW_RELIC_LICENSE_KEY'),
       secret('ISUXPORTAL_SLACK_WEBHOOK_URL'),
       secret('ISUXPORTAL_GITHUB_CLIENT_ID'),
       secret('ISUXPORTAL_GITHUB_CLIENT_SECRET'),


### PR DESCRIPTION
NEW RELICのキーがssmになかったため一時的にコメントアウトします