### PR TITLE
参加者を選手に統一

### DIFF
--- a/portal/app/javascript/RegistrationForm.tsx
+++ b/portal/app/javascript/RegistrationForm.tsx
@@ -113,17 +113,17 @@ export class RegistrationForm extends React.Component<Props, State> {
               への同意が必要です。
             </li>
             <li>
-              ご登録いただいたチーム名, 代表選手名, メンバー名は ISUCON
+              ご登録いただいたチーム名, 代表者名, メンバー名は ISUCON
               公式サイトおよびポータルなど上で広く公開されます。GitHub
               アカウントの情報はチームメンバー内で共有されます。
             </li>
             <li>
-              競技進行のため、全選手はサポート/アナウンス用の Discord サーバー (サポートチャット)
-              への参加が必要です。そのため、Discord アカウントの情報は全選手にも共有されます。
+              競技進行のため、全参加者はサポート/アナウンス用の Discord サーバー (サポートチャット)
+              への参加が必要です。そのため、Discord アカウントの情報は全参加者にも共有されます。
             </li>
             <li>参加登録が完了すると、他のチームへの参加はできなくなります。</li>
             <li>
-              1人目 (チーム代表選手) の登録後、チームメンバーを招待するための URL を確認することができます。招待 URL
+              1人目 (チーム代表者) の登録後、チームメンバーを招待するための URL を確認することができます。招待 URL
               を共有し、チームメンバー全員の登録をしてください。
             </li>
             <li>
@@ -131,9 +131,9 @@ export class RegistrationForm extends React.Component<Props, State> {
               が利用できない場合を想定してメールアドレスの記入をお願いしていますが、競技のアナウンスや連絡は、本ポータルサイトあるいは
               Discord 上で行われます。
             </li>
-            <li>チーム名・代表選手名に公序良俗に反する名前は使わないでください。</li>
+            <li>チーム名・代表者名に公序良俗に反する名前は使わないでください。</li>
             <li>
-              チーム名・代表選手名に機種依存文字・絵文字・HTMLタグなどが入っていた場合、サイトへの表示時に表現を変えさせていただく場合があります。
+              チーム名・代表者名に機種依存文字・絵文字・HTMLタグなどが入っていた場合、サイトへの表示時に表現を変えさせていただく場合があります。
             </li>
           </ul>
         </section>
@@ -185,11 +185,11 @@ export class RegistrationForm extends React.Component<Props, State> {
             </div>
             {this.isEditing() ? (
               <p className="help">
-                代表選手 {leader.name}{" "}
-                のチームへ参加しています。チーム名・代表選手メールアドレスは代表選手のみが変更可能です。
+                代表者 {leader.name}{" "}
+                のチームへ参加しています。チーム名・代表者メールアドレスは代表者のみが変更可能です。
               </p>
             ) : (
-              <p className="help">招待を利用し、代表選手 {leader.name} のチームへ参加します。</p>
+              <p className="help">招待を利用し、代表者 {leader.name} のチームへ参加します。</p>
             )}
           </div>
         </>
@@ -215,7 +215,7 @@ export class RegistrationForm extends React.Component<Props, State> {
               <p className="help"></p>
             ) : (
               <p className="help">
-                現在ログインしている方を代表とするチームを作成します。代表選手は変更できません。既存のチームへ参加する場合、代表選手もしくはチームメンバーの方より招待
+                現在ログインしている方を代表とするチームを作成します。代表者は変更できません。既存のチームへ参加する場合、代表者もしくはチームメンバーの方より招待
                 URL を受け取ってください。
               </p>
             )}
@@ -223,7 +223,7 @@ export class RegistrationForm extends React.Component<Props, State> {
 
           <div className="field">
             <label className="label" htmlFor="fieldEmailAddress">
-              代表選手メールアドレス
+              代表者メールアドレス
             </label>
             <div className="control">
               <input
@@ -250,7 +250,7 @@ export class RegistrationForm extends React.Component<Props, State> {
       <>
         <div className="field">
           <label className="label" htmlFor="fieldName">
-            {!this.props.registrationSession.team ? "代表選手名" : "選手名"}
+            {!this.props.registrationSession.team ? "代表者名" : "選手名"}
           </label>
           <div className="control">
             <input

--- a/portal/app/javascript/RegistrationStatus.tsx
+++ b/portal/app/javascript/RegistrationStatus.tsx
@@ -64,10 +64,10 @@ export class RegistrationStatus extends React.Component<Props, State> {
           <ol>
             <li>
               必要に応じ、下記より招待 URL をコピー & チームメンバーへ共有し、チームメンバーの参加登録を行ってください
-              (代表選手を含め 3 人まで)。
+              (代表者を含め 3 人まで)。
             </li>
             <li>
-              代表選手・メンバー問わず、Discord サーバーへ <b>必ず</b> 参加してください。各種アナウンスは原則 Discord
+              代表者・メンバー問わず、Discord サーバーへ <b>必ず</b> 参加してください。各種アナウンスは原則 Discord
               もしくは本サイト (ポータル) において行われます。
             </li>
           </ol>
@@ -131,7 +131,7 @@ export class RegistrationStatus extends React.Component<Props, State> {
                 Discordアカウント変更
               </a>
             </div>
-            選手名・学生申告といった登録内容の修正ができます。チーム名は代表選手のみが変更可能です。
+            選手名・学生申告といった登録内容の修正ができます。チーム名は代表者のみが変更可能です。
           </p>
           <p className="block">
             <button className="button is-danger" onClick={this.onWithdrawButtonClick.bind(this)}>
@@ -140,7 +140,7 @@ export class RegistrationStatus extends React.Component<Props, State> {
             <br />
             参加をキャンセルします。
             {this.props.registrationSession.team!.leaderId == this.props.session.contestant!.id ? (
-              <strong>代表選手のため、辞退するとチームとして参加辞退となります。</strong>
+              <strong>代表者のため、辞退するとチームとして参加辞退となります。</strong>
             ) : (
               <span>チームメンバーであるため、チームから離脱します (他のメンバーには影響しません)。</span>
             )}
@@ -173,7 +173,7 @@ export class RegistrationStatus extends React.Component<Props, State> {
               <p className="title is-5">{member.name}</p>
               <p className="subtitle is-6">
                 {this.props.registrationSession.team!.leaderId == member.id ? (
-                  <span className="tag is-danger mr-1">代表選手</span>
+                  <span className="tag is-danger mr-1">代表者</span>
                 ) : null}
                 {member.detail!.isStudent ? <span className="tag is-info mr-1">学生</span> : null}
                 GitHub @{member.detail!.githubLogin}, Discord {member.detail!.discordTag}

--- a/portal/app/javascript/admin/AdminTeamDetail.tsx
+++ b/portal/app/javascript/admin/AdminTeamDetail.tsx
@@ -86,7 +86,7 @@ export class AdminTeamDetail extends React.Component<Props, State> {
 
             <p>ID: {this.state.team.id}</p>
             <p>
-              代表選手メールアドレス:{" "}
+              代表者メールアドレス:{" "}
               <a href={`mailto:${this.state.team.detail!.emailAddress}`}>{this.state.team.detail!.emailAddress}</a>
             </p>
 


### PR DESCRIPTION
競技参加者 => 選手
参加者 => 選手
参加者名 => 選手名
代表者 => 代表選手 (これは変えなくてもよい？)
代表者メールアドレス => 代表選手メールアドレス

統一されてるほうが良いと思うので変更しました

close #113 