### PR TITLE
Allow blank value for EnvCheck

### DIFF
--- a/portal/app/models/env_check.rb
+++ b/portal/app/models/env_check.rb
@@ -3,12 +3,10 @@ require 'isuxportal/resources/notification_pb'
 class EnvCheck < ApplicationRecord
   belongs_to :team
 
-  validates :ip_address, presence: true
   validates :name, presence: true
   validates :team_id, presence: true
   validates :passed, inclusion: [true, false]
   validates :message, presence: true
-  validates :admin_message, presence: true
   validates :raw_data, presence: true
 
   scope :of_team, ->(team) { where(team: team) }


### PR DESCRIPTION
失敗時に ip_address が空の場合や、何も問題がない時に admin_message が空の場合があるので validation しないようにします。