### PR TITLE
本選かどうかの状態の条件分岐が取れていない箇所があった

### DIFF
--- a/portal/app/controllers/api/admin/dashboards_controller.rb
+++ b/portal/app/controllers/api/admin/dashboards_controller.rb
@@ -4,7 +4,7 @@ require 'isuxportal/services/admin/dashboard_pb'
 class Api::Admin::DashboardsController < Api::Admin::ApplicationController
   pb :show, Isuxportal::Proto::Services::Admin::DashboardQuery
   def show
-    final = Rails.application.config.x.final ? "final" : "qualify"
+    final = Rails.application.config.x.contest.final ? "final" : "qualify"
     clar_count = Clarification.unanswered.requested.count
     cached_lb = Rails.cache.read("leaderboard:#{final}:admin")&.yield_self { |_| Isuxportal::Proto::Resources::Leaderboard.decode(_) }
     render protobuf: Isuxportal::Proto::Services::Admin::DashboardResponse.new(

--- a/portal/app/controllers/api/audience/dashboards_controller.rb
+++ b/portal/app/controllers/api/audience/dashboards_controller.rb
@@ -4,7 +4,7 @@ class Api::Audience::DashboardsController < Api::Audience::ApplicationController
   pb :show, Isuxportal::Proto::Services::Audience::DashboardQuery
   def show
     expires_in 5.seconds, public: true, 's-maxage' => '10'
-    final = Rails.application.config.x.final ? "final" : "qualify"
+    final = Rails.application.config.x.contest.final ? "final" : "qualify"
     render protobuf: Rails.cache.read("dashboard:#{final}:audience:public") || Isuxportal::Proto::Services::Audience::DashboardResponse.new(
       leaderboard: Contest.leaderboard(admin: false, team: nil), # TODO: disable progresses
     )

--- a/portal/app/controllers/api/contestant/dashboards_controller.rb
+++ b/portal/app/controllers/api/contestant/dashboards_controller.rb
@@ -4,7 +4,7 @@ class Api::Contestant::DashboardsController < Api::Contestant::ApplicationContro
   pb :show, Isuxportal::Proto::Services::Contestant::DashboardQuery
   def show
     # See also: UpdateContestantDashboardJob
-    final = Rails.application.config.x.final ? "final" : "qualify"
+    final = Rails.application.config.x.contest.final ? "final" : "qualify"
     ptr = Rails.cache.read("dashboard:#{final}:contestant:contestant-ptr:team-#{current_team.id}") || "dashboard:#{final}:contestant:public"
     if ptr && ptr.start_with?("dashboard:#{final}:contestant:")
       ptr_resp = Rails.cache.read(ptr)

--- a/portal/app/jobs/update_contestant_dashboard_job.rb
+++ b/portal/app/jobs/update_contestant_dashboard_job.rb
@@ -4,7 +4,7 @@ require 'isuxportal/services/audience/dashboard_pb'
 
 class UpdateContestantDashboardJob < ApplicationJob
   def perform(team: nil, frozen: false)
-    final = Rails.application.config.x.final ? "final" : "qualify"
+    final = Rails.application.config.x.contest.final ? "final" : "qualify"
 
     Rails.logger.info("leaderboard")
     lb = Contest.leaderboard(admin: false, team: nil, progresses: false)


### PR DESCRIPTION
`Rails.application.config.x.final`は`{}`になって常に`true`になってた

Rails.cacheの挙動を知らないけど再デプロイでキャッシュ消えるならそのまま入れても問題なさそう(？)
