### PR TITLE
チェッカー用エンドポイントの仕様変更

### DIFF
--- a/portal/app/controllers/api/env_checks_controller.rb
+++ b/portal/app/controllers/api/env_checks_controller.rb
@@ -3,8 +3,8 @@ class Api::EnvChecksController < Api::ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :require_valid_checker_token
 
-  TEST_AMI_ID = "ami-0e22b2e5f011bcb69"
-  QUALIFY_AMI_ID = ""
+  TEST_AMI_IDS = ["ami-0e22b2e5f011bcb69"]
+  QUALIFY_AMI_IDS = []
 
   def create
     team_id = @payload[:team_id]
@@ -21,7 +21,7 @@ class Api::EnvChecksController < Api::ApplicationController
     )
     @env_check.save!
 
-    if name.starts_with("qualify")
+    if name.starts_with("qualify") && name != "qualify-unknown"
       nameNum = name.delete_prefix("qualify").to_i
 
       instance = ContestantInstance.find_or_initialize_by(
@@ -40,11 +40,11 @@ class Api::EnvChecksController < Api::ApplicationController
   def info
     team = Team.find(@payload[:team_id])
 
-    ami_id = case params[:name]
+    ami_ids = case params[:name]
       when "test-boot", "test-ssh"
-        TEST_AMI_ID
-      when "qualify1", "qualify2", "qualify3"
-        QUALIFY_AMI_ID
+        TEST_AMI_IDS
+      when "qualify"
+        QUALIFY_AMI_IDS
       else
         return render status: :bad_request, body: "unknown name param"
       end
@@ -52,7 +52,8 @@ class Api::EnvChecksController < Api::ApplicationController
     az_id = team.availability_zone
 
     render json: {
-      ami_id: ami_id,
+      ami_id: ami_ids.first || "",
+      ami_ids: ami_ids,
       az_id: az_id,
     }
   end


### PR DESCRIPTION
予選用のチェッカー実装中に仕様変更したくなったので更新しました (事前に伝えていた仕様から変更あってすみません)

* AMI ID を複数受け取れるように (#149)
* info では `qualify` で受け付けるように
  * 当初 `qualify1` のようなものでやろうと考えてましたが、何番目のインスタンスかわからない可能性もあったので、こっちでは別物を送るようにしました
* `qualify-unknown` の追加
  * 適切な Name タグが外されている場合などには `qualify1`, `qualify2`, `qualify3` のどれかわからないケースが有り、その場合には `qualify-unknown` として送って、 ContestantInstance には登録しないようにしました。