### PR TITLE
Scale out for qualify

### DIFF
--- a/hako/isuxportal-prd-fargate.jsonnet
+++ b/hako/isuxportal-prd-fargate.jsonnet
@@ -5,7 +5,7 @@ local base = import './isuxportal-prd-base.libsonnet';
 
 base {
   scheduler+: utils.ecsSchedulerFargate {
-    desired_count: 2,
+    desired_count: 50,
     elb_v2: utils.albInternetFacing,
     capacity_provider_strategy: [
       { capacity_provider: 'FARGATE_SPOT', weight: 1 },

--- a/hako/isuxportal-prd-grpc-fargate.jsonnet
+++ b/hako/isuxportal-prd-grpc-fargate.jsonnet
@@ -5,7 +5,9 @@ local base = import './isuxportal-prd-base.libsonnet';
 
 base {
   scheduler+: utils.ecsSchedulerFargate {
-    desired_count: 3,
+    desired_count: 15,
+    cpu: '512',
+    memory: '1024',
     elb_v2: utils.grpcNlbInternal {
       protocol: 'TLS',
     },
@@ -14,6 +16,8 @@ base {
     ],
   },
   app+: {
+    cpu: 512 - 64,
+    memory: 1024 - 128,
     command: ['bundle', 'exec', 'rails', 'runner', 'Griffin::Server.run(port: 4000)'],
     env+: {
       GRIFFIN_POOL_MIN: '20',


### PR DESCRIPTION
予選当日用に ECS タスク増やします。

* isuxportal-prd-fargate
  * `WORKER_NUM=1 THREADS_NUM=3` なので1タスク同時に3リクエスト処理可能
  * 50*3 = 150リクエスト同時に処理が可能
  * 競技開始直後はチェッカーによるリクエストも多いので、かなり余裕を持った数にした
    * #183 によって選手向けダッシュボードが軽くなったので同一サービスがアクセスするようになるので、その分も多めに
* isuxportal-prd-grpc-fargate
  * 1タスクあたり50ストリーム
  * 50*15 = 750
  * 600 台からアクセスされるので、余裕を持った数に
  * https://github.com/isucon/isucon11-portal/commit/d987c10f9c121aaae5d3cb853c7a9b3d326c7f07#diff-608d2a63bf9f7405a25db1de72013cf42eb8d2ca1517e31453d8771ddfb0b592 を参考にした