### PR TITLE
チェッカーが失敗したときにSlackを飛ばす

### DIFF
--- a/portal/app/controllers/api/env_checks_controller.rb
+++ b/portal/app/controllers/api/env_checks_controller.rb
@@ -39,7 +39,7 @@ class Api::EnvChecksController < Api::ApplicationController
       end
 
       if !passed
-        SlackWebhookJob.perform_later(text: ":shocked_face_with_exploding_head: *Checker failed:* team_id=#{team_id} name=#{name}")
+        SlackWebhookJob.perform_later(text: ":shocked_face_with_exploding_head: *Checker failed:* <https://#{default_url_options.fetch(:host)}/admin/teams/#{team_id}|team_id=#{team_id}> name=#{name}")
       end
     end
   end


### PR DESCRIPTION
どこまで情報載せるかってなりましたがこれだけあれば画面から見つけられるのでいいかなってなりました

refs #178 
